### PR TITLE
Updated netinfo dependency version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ name = "netinfo"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-netinfo = "0.3.0"
+netinfo = "0.4.0"
 enum_primitive = "0.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,12 +343,10 @@ pub unsafe extern fn netinfo_int_get_ips(i: ni_net_interface, ip4_array_out: *mu
             let mut ipv4_vec: Vec<ni_ipv4_addr> = Vec::new();
             let mut ipv6_vec: Vec<ni_ipv6_addr> = Vec::new();
 
-            if let Some(ip_vec) = i.get_ips_as_slice() {
-                for &ip in ip_vec {
-                    match ip {
-                        IpAddr::V4(ipv4) => { ipv4_vec.push(ipv4.into()); }
-                        IpAddr::V6(ipv6) => { ipv6_vec.push(ipv6.into()); }
-                    }
+            for ip in i.get_ips() {
+                match ip {
+                    IpAddr::V4(ipv4) => { ipv4_vec.push(ipv4.into()); }
+                    IpAddr::V6(ipv6) => { ipv6_vec.push(ipv6.into()); }
                 }
             }
 


### PR DESCRIPTION
I couldn't compile this library using cargo because netinfo 0.3.0 seems to have broken dependencies. After updating to netinfo 0.4.0 and fixing one compile error, everything seems to work (tested in GNOME Usage 4.5 / commit e1abfc0 - the last version using this library).

I've never used Rust before, so there might be further problems, I just made sure it compiles and works in my use case